### PR TITLE
Remove user that is not longer active

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - gparvin
 - JustinKuli
 - willkutler
-- ycao56
 - mprahl
 reviewers:
 - ChunxiAlexLuo
@@ -14,5 +13,4 @@ reviewers:
 - gparvin
 - JustinKuli
 - willkutler
-- ycao56
 - mprahl


### PR DESCRIPTION
Remove an inactive user that is no longer a contributor.

Refs:
 - https://github.com/stolostron/backlog/issues/21546

Signed-off-by: Gus Parvin <gparvin@redhat.com>