### PR TITLE
Support an alternative managed cluster namespace on the Hub

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -74,6 +74,13 @@ jobs:
         export GOPATH=$(go env GOPATH)
         make e2e-test-coverage
 
+    - name: E2E Tests That Simulate Hosted Mode
+      run: |
+        export GOPATH=$(go env GOPATH)
+        export E2E_CLUSTER_NAMESPACE="other-namespace"
+        export COVERAGE_E2E_OUT=coverage_e2e_hosted_mode.out
+        make e2e-test-coverage
+
     - name: Test Coverage Verification
       if: ${{ github.event_name == 'pull_request' }}
       run: |

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ else
 endif
 # Test coverage threshold
 export COVERAGE_MIN ?= 69
+COVERAGE_E2E_OUT ?= coverage_e2e.out
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
@@ -287,7 +288,7 @@ e2e-build-instrumented:
 
 .PHONY: e2e-run-instrumented
 e2e-run-instrumented: e2e-build-instrumented
-	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) WATCH_NAMESPACE=$(WATCH_NAMESPACE) ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=coverage_e2e.out &>build/_output/controller.log &
+	HUB_CONFIG=$(HUB_CONFIG) MANAGED_CONFIG=$(MANAGED_CONFIG) WATCH_NAMESPACE=$(WATCH_NAMESPACE) ./build/_output/bin/$(IMG)-instrumented -test.run "^TestRunMain$$" -test.coverprofile=$(COVERAGE_E2E_OUT) &>build/_output/controller.log &
 
 .PHONY: e2e-stop-instrumented
 e2e-stop-instrumented:

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 )
@@ -14,7 +15,9 @@ import (
 // TestRunMain wraps the main() function in order to build a test binary and collection coverage for
 // E2E/Integration tests. Controller CLI flags are also passed in here.
 func TestRunMain(t *testing.T) {
-	os.Args = append(os.Args, "--leader-elect=false")
+	os.Args = append(
+		os.Args, "--leader-elect=false", fmt.Sprintf("--cluster-namespace=%s", os.Getenv("E2E_CLUSTER_NAMESPACE")),
+	)
 
 	main()
 }

--- a/test/e2e/case1_mutation_recovery_test.go
+++ b/test/e2e/case1_mutation_recovery_test.go
@@ -20,15 +20,15 @@ const (
 
 var _ = Describe("Test mutation recovery", func() {
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("apply", "-f", case1PolicyYaml, "-n", testNamespace,
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("apply", "-f", case1PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).Should(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case1PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
@@ -46,8 +46,8 @@ var _ = Describe("Test mutation recovery", func() {
 		Expect(managedPlc).NotTo(BeNil())
 	})
 	AfterEach(func() {
-		By("Deleting a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("delete", "-f", case1PolicyYaml, "-n", testNamespace,
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("delete", "-f", case1PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).Should(BeNil())
 		_, err = utils.KubectlWithOutput(
@@ -87,7 +87,7 @@ var _ = Describe("Test mutation recovery", func() {
 			clientHubDynamic,
 			gvrPolicy,
 			case1PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Eventually(func() interface{} {
@@ -124,7 +124,7 @@ var _ = Describe("Test mutation recovery", func() {
 			clientHubDynamic,
 			gvrPolicy,
 			case1PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Eventually(func() interface{} {
@@ -156,7 +156,7 @@ var _ = Describe("Test mutation recovery", func() {
 			clientHubDynamic,
 			gvrPolicy,
 			case1PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Eventually(func() interface{} {

--- a/test/e2e/case2_status_sync_test.go
+++ b/test/e2e/case2_status_sync_test.go
@@ -23,15 +23,15 @@ const (
 
 var _ = Describe("Test status sync", func() {
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("apply", "-f", case2PolicyYaml, "-n", testNamespace,
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("apply", "-f", case2PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).To(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case2PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
@@ -49,8 +49,8 @@ var _ = Describe("Test status sync", func() {
 		Expect(managedPlc).NotTo(BeNil())
 	})
 	AfterEach(func() {
-		By("Deleting a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("delete", "-f", case2PolicyYaml, "-n", testNamespace,
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("delete", "-f", case2PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).To(BeNil())
 		_, err = utils.KubectlWithOutput(
@@ -100,7 +100,7 @@ var _ = Describe("Test status sync", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case2PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -154,7 +154,7 @@ var _ = Describe("Test status sync", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case2PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -208,7 +208,7 @@ var _ = Describe("Test status sync", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case2PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -308,7 +308,7 @@ var _ = Describe("Test status sync", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case2PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 

--- a/test/e2e/case3_multiple_templates_test.go
+++ b/test/e2e/case3_multiple_templates_test.go
@@ -34,15 +34,15 @@ func getCompliant(policy *unstructured.Unstructured) string {
 
 var _ = Describe("Test status sync with multiple templates", func() {
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("apply", "-f", case3PolicyYaml, "-n", testNamespace,
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("apply", "-f", case3PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).To(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case3PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
@@ -60,8 +60,8 @@ var _ = Describe("Test status sync with multiple templates", func() {
 		Expect(managedPlc).NotTo(BeNil())
 	})
 	AfterEach(func() {
-		By("Deleting a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("delete", "-f", case3PolicyYaml, "-n", testNamespace,
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("delete", "-f", case3PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).To(BeNil())
 		_, err = utils.KubectlWithOutput(
@@ -162,7 +162,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -221,7 +221,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -266,7 +266,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -328,7 +328,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -390,7 +390,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -435,14 +435,14 @@ var _ = Describe("Test status sync with multiple templates", func() {
 			"-f",
 			"../resources/case3_multiple_templates/case3-test-policy-without-template1.yaml",
 			"-n",
-			testNamespace,
+			clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).To(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case3PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
@@ -485,7 +485,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 
@@ -530,14 +530,14 @@ var _ = Describe("Test status sync with multiple templates", func() {
 			"-f",
 			"../resources/case3_multiple_templates/case3-test-policy-without-template2.yaml",
 			"-n",
-			testNamespace,
+			clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).To(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case3PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
@@ -580,7 +580,7 @@ var _ = Describe("Test status sync with multiple templates", func() {
 				clientHubDynamic,
 				gvrPolicy,
 				case3PolicyName,
-				testNamespace,
+				clusterNamespaceOnHub,
 				true,
 				defaultTimeoutSeconds)
 

--- a/test/e2e/case4_status_merge_test.go
+++ b/test/e2e/case4_status_merge_test.go
@@ -19,15 +19,15 @@ const (
 
 var _ = Describe("Test status sync with multiple templates", func() {
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + testNamespace)
-		_, err := utils.KubectlWithOutput("apply", "-f", case4PolicyYaml, "-n", testNamespace,
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
+		_, err := utils.KubectlWithOutput("apply", "-f", case4PolicyYaml, "-n", clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).Should(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case4PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
@@ -50,13 +50,13 @@ var _ = Describe("Test status sync with multiple templates", func() {
 		Expect(managedPlc).NotTo(BeNil())
 	})
 	AfterEach(func() {
-		By("Deleting a policy on hub cluster in ns:" + testNamespace)
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
 		_, err := utils.KubectlWithOutput(
 			"delete",
 			"-f",
 			case4PolicyYaml,
 			"-n",
-			testNamespace,
+			clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).Should(BeNil())
 		_, err = utils.KubectlWithOutput(

--- a/test/e2e/case6_event_msg_test.go
+++ b/test/e2e/case6_event_msg_test.go
@@ -19,24 +19,24 @@ const (
 
 var _ = Describe("Test event message handling", func() {
 	BeforeEach(func() {
-		By("Creating a policy on hub cluster in ns:" + testNamespace)
+		By("Creating a policy on hub cluster in ns:" + clusterNamespaceOnHub)
 		_, err := utils.KubectlWithOutput(
 			"apply",
 			"-f",
 			case6PolicyYaml,
 			"-n",
-			testNamespace,
+			clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).Should(BeNil())
 		hubPlc := utils.GetWithTimeout(
 			clientHubDynamic,
 			gvrPolicy,
 			case6PolicyName,
-			testNamespace,
+			clusterNamespaceOnHub,
 			true,
 			defaultTimeoutSeconds)
 		Expect(hubPlc).NotTo(BeNil())
-		By("Creating a policy on managed cluster in ns:" + testNamespace)
+		By("Creating a policy on managed cluster in ns:" + clusterNamespaceOnHub)
 		_, err = utils.KubectlWithOutput(
 			"apply",
 			"-f",
@@ -55,13 +55,13 @@ var _ = Describe("Test event message handling", func() {
 		Expect(managedPlc).NotTo(BeNil())
 	})
 	AfterEach(func() {
-		By("Deleting a policy on hub cluster in ns:" + testNamespace)
+		By("Deleting a policy on hub cluster in ns:" + clusterNamespaceOnHub)
 		_, err := utils.KubectlWithOutput(
 			"delete",
 			"-f",
 			case6PolicyYaml,
 			"-n",
-			testNamespace,
+			clusterNamespaceOnHub,
 			"--kubeconfig=../../kubeconfig_hub")
 		Expect(err).Should(BeNil())
 		_, err = utils.KubectlWithOutput(

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -40,6 +40,7 @@ var (
 	kubeconfigHub         string
 	kubeconfigManaged     string
 	defaultTimeoutSeconds int
+	clusterNamespaceOnHub string
 
 	defaultImageRegistry string
 
@@ -85,14 +86,21 @@ var _ = BeforeSuite(func() {
 	testNamespace = "managed"
 	defaultTimeoutSeconds = 30
 	By("Create Namespace if needed")
+
+	if os.Getenv("E2E_CLUSTER_NAMESPACE") == "" {
+		clusterNamespaceOnHub = testNamespace
+	} else {
+		clusterNamespaceOnHub = os.Getenv("E2E_CLUSTER_NAMESPACE")
+	}
+
 	namespacesHub := clientHub.CoreV1().Namespaces()
 	if _, err := namespacesHub.Get(
 		context.TODO(),
-		testNamespace,
+		clusterNamespaceOnHub,
 		metav1.GetOptions{}); err != nil && errors.IsNotFound(err) {
 		Expect(namespacesHub.Create(context.TODO(), &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: testNamespace,
+				Name: clusterNamespaceOnHub,
 			},
 		}, metav1.CreateOptions{})).NotTo(BeNil())
 	}

--- a/tool/options.go
+++ b/tool/options.go
@@ -12,8 +12,7 @@ var log = ctrl.Log.WithName("cmd")
 
 // PolicySpecSyncOptions for command line flag parsing
 type PolicySpecSyncOptions struct {
-	ClusterName               string
-	ClusterNamespace          string
+	ClusterNamespaceOnHub     string
 	HubConfigFilePathName     string
 	ManagedConfigFilePathName string
 	EnableLease               bool
@@ -30,17 +29,10 @@ func ProcessFlags() {
 	flag := pflag.CommandLine
 
 	flag.StringVar(
-		&Options.ClusterName,
-		"cluster-name",
-		Options.ClusterName,
-		"Name of this endpoint.",
-	)
-
-	flag.StringVar(
-		&Options.ClusterNamespace,
+		&Options.ClusterNamespaceOnHub,
 		"cluster-namespace",
-		Options.ClusterNamespace,
-		"Cluster Namespace of this endpoint in hub.",
+		Options.ClusterNamespaceOnHub,
+		"The cluster namespace on the Hub. This defaults to the namespace that the controller watches.",
 	)
 
 	flag.StringVar(


### PR DESCRIPTION
This is required for running the Policy addon in hosted mode because the
namespace on the hosting cluster might be different than the cluster
name.

Related:
https://github.com/stolostron/backlog/issues/24362