### PR TITLE
Use event name to break timestamp ties

### DIFF
--- a/test/e2e/case7_ts_collision_test.go
+++ b/test/e2e/case7_ts_collision_test.go
@@ -15,11 +15,14 @@ const (
 	case7Event1        string = "../resources/case7_ts_collision/case7-event-one.yaml"
 	case7Event2        string = "../resources/case7_ts_collision/case7-event-two.yaml"
 	case7Event3        string = "../resources/case7_ts_collision/case7-event-three.yaml"
+	case7Event4        string = "../resources/case7_ts_collision/case7-event-four.yaml"
+	case7Event5        string = "../resources/case7_ts_collision/case7-event-five.yaml"
+	case7Event6        string = "../resources/case7_ts_collision/case7-event-six.yaml"
 	case7hubconfig     string = "--kubeconfig=../../kubeconfig_hub"
 	case7managedconfig string = "--kubeconfig=../../kubeconfig_managed"
 )
 
-var _ = Describe("Test event sorting when timestamps collide", Ordered, func() {
+var _ = Describe("Test event sorting by name when timestamps collide", Ordered, func() {
 	It("Creates the policy and one event, and shows compliant", func() {
 		_, err := utils.KubectlWithOutput(
 			"apply", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig,
@@ -93,5 +96,82 @@ var _ = Describe("Test event sorting when timestamps collide", Ordered, func() {
 		utils.Kubectl("delete", "-f", case7Event1, "-n", testNamespace, case7managedconfig)
 		utils.Kubectl("delete", "-f", case7Event2, "-n", testNamespace, case7managedconfig)
 		utils.Kubectl("delete", "-f", case7Event3, "-n", testNamespace, case7managedconfig)
+	})
+})
+
+var _ = Describe("Test event sorting by eventtime when timestamps collide", Ordered, func() {
+	It("Creates the policy and one event, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7Event4, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case7PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			return getCompliant(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+
+	It("Creates a second event with the same timestamp, and shows noncompliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event5, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case7PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			return getCompliant(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+	})
+
+	It("Creates a third with the same timestamp, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event6, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case7PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			return getCompliant(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+
+	AfterAll(func() {
+		utils.Kubectl("delete", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig)
+		utils.Kubectl("delete", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig)
+		utils.Kubectl("delete", "-f", case7Event4, "-n", testNamespace, case7managedconfig)
+		utils.Kubectl("delete", "-f", case7Event5, "-n", testNamespace, case7managedconfig)
+		utils.Kubectl("delete", "-f", case7Event6, "-n", testNamespace, case7managedconfig)
 	})
 })

--- a/test/e2e/case7_ts_collision_test.go
+++ b/test/e2e/case7_ts_collision_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2020 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"open-cluster-management.io/governance-policy-propagator/test/utils"
+)
+
+const (
+	case7PolicyYaml    string = "../resources/case7_ts_collision/case7-policy.yaml"
+	case7PolicyName    string = "default.case7-test-policy"
+	case7Event1        string = "../resources/case7_ts_collision/case7-event-one.yaml"
+	case7Event2        string = "../resources/case7_ts_collision/case7-event-two.yaml"
+	case7Event3        string = "../resources/case7_ts_collision/case7-event-three.yaml"
+	case7hubconfig     string = "--kubeconfig=../../kubeconfig_hub"
+	case7managedconfig string = "--kubeconfig=../../kubeconfig_managed"
+)
+
+var _ = Describe("Test event sorting when timestamps collide", Ordered, func() {
+	It("Creates the policy and one event, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		_, err = utils.KubectlWithOutput(
+			"apply", "-f", case7Event1, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case7PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			return getCompliant(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+
+	It("Creates a second event with the same timestamp, and shows noncompliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event2, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case7PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			return getCompliant(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("NonCompliant"))
+	})
+
+	It("Creates a third with the same timestamp, and shows compliant", func() {
+		_, err := utils.KubectlWithOutput(
+			"apply", "-f", case7Event3, "-n", testNamespace, case7managedconfig,
+		)
+		Expect(err).Should(BeNil())
+
+		Eventually(func() interface{} {
+			managedPlc := utils.GetWithTimeout(
+				clientManagedDynamic,
+				gvrPolicy,
+				case7PolicyName,
+				testNamespace,
+				true,
+				defaultTimeoutSeconds)
+
+			return getCompliant(managedPlc)
+		}, defaultTimeoutSeconds, 1).Should(Equal("Compliant"))
+	})
+
+	AfterAll(func() {
+		utils.Kubectl("delete", "-f", case7PolicyYaml, "-n", clusterNamespaceOnHub, case7hubconfig)
+		utils.Kubectl("delete", "-f", case7PolicyYaml, "-n", testNamespace, case7managedconfig)
+		utils.Kubectl("delete", "-f", case7Event1, "-n", testNamespace, case7managedconfig)
+		utils.Kubectl("delete", "-f", case7Event2, "-n", testNamespace, case7managedconfig)
+		utils.Kubectl("delete", "-f", case7Event3, "-n", testNamespace, case7managedconfig)
+	})
+})

--- a/test/resources/case7_ts_collision/case7-event-five.yaml
+++ b/test/resources/case7_ts_collision/case7-event-five.yaml
@@ -1,0 +1,24 @@
+action: "filler"
+apiVersion: v1
+count: 1
+eventTime: "2022-10-03T14:40:47.222222Z"
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: NonCompliant; violation - a problem sandwich
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  name: default.case7-test-policy.b.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: "filler"
+reportingInstance: "filler"
+source:
+  component: configuration-policy-controller
+type: Warning

--- a/test/resources/case7_ts_collision/case7-event-four.yaml
+++ b/test/resources/case7_ts_collision/case7-event-four.yaml
@@ -1,0 +1,24 @@
+action: "filler"
+apiVersion: v1
+count: 1
+eventTime: "2022-10-03T14:40:47.111111Z"
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this is the oldest event
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  name: default.case7-test-policy.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: "filler"
+reportingInstance: "filler"
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-one.yaml
+++ b/test/resources/case7_ts_collision/case7-event-one.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+count: 1
+eventTime: null
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this is the oldest event
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-six.yaml
+++ b/test/resources/case7_ts_collision/case7-event-six.yaml
@@ -1,0 +1,25 @@
+action: "filler"
+apiVersion: v1
+count: 1
+eventTime: "2022-10-03T14:40:47.333333Z"
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this should be the most recent
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.c.171a96193d32cf17
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: "filler"
+reportingInstance: "filler"
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-three.yaml
+++ b/test/resources/case7_ts_collision/case7-event-three.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+count: 1
+eventTime: null
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: Compliant; notification - this should be the most recent
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.171a96193dea32f8
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: configuration-policy-controller
+type: Normal

--- a/test/resources/case7_ts_collision/case7-event-two.yaml
+++ b/test/resources/case7_ts_collision/case7-event-two.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+count: 1
+eventTime: null
+firstTimestamp: "2022-10-03T14:40:47Z"
+involvedObject:
+  apiVersion: policy.open-cluster-management.io/v1
+  kind: Policy
+  name: default.case7-test-policy
+  namespace: managed
+  uid: 53719093-857c-4c9b-a1d2-187dfb8c6657
+kind: Event
+lastTimestamp: "2022-10-03T14:40:47Z"
+message: NonCompliant; violation - a problem sandwich
+metadata:
+  creationTimestamp: "2022-10-03T14:40:47Z"
+  # Name format based on https://github.com/kubernetes/client-go/blob/f24bd6967c440b1e8985cec4460c40d92dca9e65/tools/record/event.go#L382
+  name: default.case7-test-policy.171a96193dea32f4
+  namespace: managed
+reason: 'policy: managed/case7-test-policy-trustedcontainerpolicy'
+reportingComponent: ""
+reportingInstance: ""
+source:
+  component: configuration-policy-controller
+type: Warning

--- a/test/resources/case7_ts_collision/case7-policy.yaml
+++ b/test/resources/case7_ts_collision/case7-policy.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: default.case7-test-policy
+  labels:
+    policy.open-cluster-management.io/cluster-name: managed
+    policy.open-cluster-management.io/cluster-namespace: managed
+    policy.open-cluster-management.io/root-policy: default.case7-test-policy
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policies.ibm.com/v1alpha1
+        kind: TrustedContainerPolicy
+        metadata:
+          name: case7-test-policy-trustedcontainerpolicy
+        spec:
+          severity: low
+          namespaceSelector:
+            include: ["default"]
+            exclude: ["kube-system"]
+          remediationAction: inform
+          imageRegistry: quay.io
+


### PR DESCRIPTION
It is possible for two events to be emitted in the same millisecond. If this happens, the last timestamps can't be used to consistently order the events. However, events emitted by client-go's recorder are suffixed with a hexadecimal nanosecond timestamp, which might be used to order these events.

Refs:
 - https://github.com/stolostron/backlog/issues/26039

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>